### PR TITLE
Added basic support for GNU Readline

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,27 @@ else
 fi
 AC_SUBST(TECLA_LIBS)
 #
+#	Check to see if we should use Readline for command line editing.
+#
+AC_ARG_WITH(readline,
+	    AC_HELP_STRING([--with-readline],
+                           [use Readline command line editing library [default=no]]),
+			   [WITH_READLINE=$withval],
+			   [WITH_READLINE=no])
+if (test $WITH_READLINE = yes) then
+#
+#	Check if user set particular Readline libraries to use and if
+#	not set defaults.
+#
+  AC_DEFINE([USE_READLINE], [], [use Readline command line editing library])
+  if (test -z "$READLINE_LIBS") then
+    READLINE_LIBS="-lreadline"
+  fi
+else
+  READLINE_LIBS=""
+fi
+AC_SUBST(READLINE_LIBS)
+#
 #	Check to see if we should use libsigsegv to handle segmentation faults.
 #
 AC_ARG_WITH(libsigsegv,

--- a/src/IO_Stuff/IO_Manager.cc
+++ b/src/IO_Stuff/IO_Manager.cc
@@ -38,6 +38,11 @@
 #include <sys/termios.h>
 #endif
 #include "libtecla.h"
+#else
+#ifdef USE_READLINE
+#include <readline/readline.h>
+#include <readline/history.h>
+#endif
 #endif
 
 //	IO Stuff class definitions
@@ -134,6 +139,30 @@ IO_Manager::getInput(char* buf, int maxSize, FILE* stream)
 	}
       return n;
     }
+#else
+#ifdef USE_READLINE
+  rl_instream = stream;
+  char* line = readline(contFlag ? contPrompt.c_str() : prompt.c_str());
+
+  contFlag = true;
+
+  if(line == NULL)
+    {
+      return 0;
+    }
+
+  if(*line)
+    {
+      add_history(line);
+    }
+
+  string input;
+  input.append(line);
+  input.push_back('\n');
+  memset(buf, 0, maxSize - 1);
+  strncpy(buf, input.c_str(), maxSize - 2);
+  return strlen(buf);
+#endif
 #endif
 
   //

--- a/src/Main/Makefile.am
+++ b/src/Main/Makefile.am
@@ -59,6 +59,7 @@ maude_LDADD = \
 	$(BUDDY_LIB) \
 	$(CVC4_LIB) \
 	$(TECLA_LIBS) \
+	$(READLINE_LIBS) \
 	$(LIBSIGSEGV_LIB) \
 	$(GMP_LIBS) \
 	$(DLMALLOC_LIB)


### PR DESCRIPTION
This commit adds support for GNU Readline to the Maude REPL.

You can use it by configuring with `--without-tecla --with-readline`. Maybe someone who knows more about autotools than me can change `configure.ac` so that the two configure flags are mutually exclusive.

I think someone will have to `autoreconf -vif` the project and commit those changes if this commit is merged (I didn't want to pollute the diff and wasn't sure if my autoconf/automake versions would be the same as yours).